### PR TITLE
including prompt and login_hint to options

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -121,6 +121,8 @@ module OmniAuth
           response_type: options.response_type,
           scope: options.scope,
           state: new_state,
+          login_hint: options.login_hint,
+          prompt: options.prompt,
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
         }
@@ -199,15 +201,15 @@ module OmniAuth
 
       def key_or_secret
         case options.client_signing_alg
-          when :HS256, :HS384, :HS512
-            return client_options.secret
-          when :RS256, :RS384, :RS512
-            if options.client_jwk_signing_key
-              return parse_jwk_key(options.client_jwk_signing_key)
-            elsif options.client_x509_signing_key
-              return parse_x509_key(options.client_x509_signing_key)
-            end
-          else
+        when :HS256, :HS384, :HS512
+          return client_options.secret
+        when :RS256, :RS384, :RS512
+          if options.client_jwk_signing_key
+            return parse_jwk_key(options.client_jwk_signing_key)
+          elsif options.client_x509_signing_key
+            return parse_x509_key(options.client_x509_signing_key)
+          end
+        else
         end
       end
 


### PR DESCRIPTION
Why?

neither prompt nor login_hint were being used as auth params

How?

I just added the prompt and login_hint to the opts hash

Risks

None, I think

Requested Reviewers
