### PR TITLE
fix: Gracefully handle state mismatch

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -104,7 +104,7 @@ module OmniAuth
         if error
           raise CallbackError.new(params['error'], params['error_description'] || params['error_reason'], params['error_uri'])
         elsif params['state'].to_s.empty? || params['state'] != stored_state
-          return Rack::Response.new(['401 Unauthorized'], 401).finish
+          raise CallbackError.new('Invalid state parameter')
         elsif !params['code']
           return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(params['error']))
         else

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -213,10 +213,8 @@ module OmniAuth
         request.stubs(:path_info).returns('')
 
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
-        result = strategy.callback_phase
-
-        assert result.kind_of?(Array)
-        assert result.first == 401, "Expecting unauthorized"
+        strategy.expects(:fail!)
+        strategy.callback_phase
       end
 
       def test_callback_phase_without_code
@@ -363,12 +361,10 @@ module OmniAuth
         code = SecureRandom.hex(16)
         request.stubs(:params).returns('code' => code, 'state' => 43)
         request.stubs(:path_info).returns('')
+
         strategy.call!('rack.session' => session)
-
-        result = strategy.callback_phase
-
-        assert result.kind_of?(Array)
-        assert result.first == 401, 'Expecting unauthorized'
+        strategy.expects(:fail!)
+        strategy.callback_phase
       end
 
       def test_option_client_auth_method


### PR DESCRIPTION
Allow our code to handle cases where there is a state mismatch.