### PR TITLE
fix: Handle SSL error on callback.

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -124,7 +124,7 @@ module OmniAuth
         fail!(:invalid_credentials, e)
       rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
         fail!(:timeout, e)
-      rescue ::SocketError => e
+      rescue ::SocketError, OpenSSL::SSL::SSLError => e
         fail!(:failed_to_connect, e)
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -301,6 +301,21 @@ module OmniAuth
         strategy.callback_phase
       end
 
+      def test_callback_phase_with_ssl_error
+        code = SecureRandom.hex(16)
+        state = SecureRandom.hex(16)
+        nonce = SecureRandom.hex(16)
+        request.stubs(:params).returns('code' => code, 'state' => state)
+        request.stubs(:path_info).returns('')
+
+        strategy.options.issuer = 'example.com'
+
+        strategy.stubs(:access_token).raises(OpenSSL::SSL::SSLError)
+        strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
+        strategy.expects(:fail!)
+        strategy.callback_phase
+      end
+
       def test_info
         info = strategy.info
         assert_equal user_info.name, info[:name]


### PR DESCRIPTION
Closes https://github.com/Zetatango/zetatango/issues/6150

We saw this intermittent SSL error on callback after login. We have a way of handling errors during the OpenId Connect phase which is to tell the user a temporary error occurred and give them the option to retry. The way to give them this option is to ensure the `fail!` call is made.

@gregfletch and @dragoszt please review