### PR TITLE
Add access token raw attributes to strategy extra attributes 

### DIFF
--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -2,6 +2,7 @@
 
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.3.0'
+    # original version VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -76,7 +76,7 @@ module OmniAuth
       end
 
       extra do
-        { raw_info: user_info.raw_attributes }
+        { raw_info: raw_attributes }
       end
 
       credentials do
@@ -302,6 +302,13 @@ module OmniAuth
 
       def params
         request.params
+      end
+
+      def raw_attributes
+        hash = {}
+        hash.merge! user_info.raw_attributes if user_info&.raw_attributes.present?
+        hash.merge! access_token.raw_attributes if access_token&.raw_attributes.present?
+        hash
       end
 
       class CallbackError < StandardError

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -144,6 +144,8 @@ module OmniAuth
         access_token.stubs(:expires_in)
         access_token.stubs(:scope)
         access_token.stubs(:id_token).returns(File.read('test/fixtures/id_token.txt'))
+        access_token.stubs(:raw_attributes).returns(access_token_raw_attributes)
+
         client.expects(:access_token!).at_least_once.returns(access_token)
         access_token.expects(:userinfo!).returns(user_info)
 
@@ -187,6 +189,7 @@ module OmniAuth
         access_token.stubs(:expires_in)
         access_token.stubs(:scope)
         access_token.stubs(:id_token).returns(File.read('test/fixtures/id_token.txt'))
+        access_token.stubs(:raw_attributes).returns(access_token_raw_attributes)
         client.expects(:access_token!).at_least_once.returns(access_token)
         access_token.expects(:userinfo!).returns(user_info)
 
@@ -330,7 +333,10 @@ module OmniAuth
       end
 
       def test_extra
-        assert_equal({ raw_info: user_info.as_json }, strategy.extra)
+        access_token = stub('OpenIDConnect::AccessToken')
+        access_token.stubs(:raw_attributes).returns(access_token_raw_attributes)
+        strategy.instance_variable_set(:@access_token, access_token)
+        assert_equal({ raw_info: user_info.as_json.merge(access_token_raw_attributes) }, strategy.extra)
       end
 
       def test_credentials
@@ -346,6 +352,7 @@ module OmniAuth
         access_token.stubs(:access_token).returns(SecureRandom.hex(16))
         access_token.stubs(:refresh_token).returns(SecureRandom.hex(16))
         access_token.stubs(:expires_in).returns(Time.now)
+        access_token.stubs(:raw_attributes).returns(access_token_raw_attributes)
         access_token.stubs(:scope).returns('openidconnect')
         access_token.stubs(:id_token).returns(File.read('test/fixtures/id_token.txt'))
 

--- a/test/strategy_test_case.rb
+++ b/test/strategy_test_case.rb
@@ -28,6 +28,9 @@ class StrategyTestCase < MiniTest::Test
       phone_number: Faker::PhoneNumber.phone_number,
       website: Faker::Internet.url,
     )
+
+  def access_token_raw_attributes
+    @extra_attributes ||= { extra_attribute: 1 }
   end
 
   def request


### PR DESCRIPTION
Story: 

https://github.com/Zetatango/zetatango/issues/6610

Reason: 

Need to collect the refresh token expiration time but it's only available in the access token raw attributes

How:

Merge the access_token raw attributes to strategy extra attributes

Reviewers:

@bcarr092 @miguelakira 